### PR TITLE
Adding a separator between event description and 'about zirbes.org' content

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,18 +59,27 @@
           </p>
         </div>
       </div>
+	
+      <hr/>
+      
+      <div class="row marketing">
+        <div class="col-lg-9">
+	  <span class="lead">Tell me, what is Zirbes.org?</span>
+        </div>
+      </div>
 
       <div class="row marketing">
         <div class="col-lg-6">
-          <h4>Food</h4>
+          <h4>It's Food...</h4>
           <p>Meeting up in the Downtown and Northeast Minneapolis area for lunch and happy hour discussions.</p>
 
-          <h4>Beer</h4>
+          <h4>It's Beer...</h4>
           <p>Tossing around problems, ideas and the occasional solution at your local Minneapolis watering hole.</p>
 
-          <h4>Tech</h4>
+          <h4>It's Tech...</h4>
           <p>Currently focusing on JVM technologies from your Phone to the Cloud.</p>
-        </div>
+          <h4> It's Fantastic!</h4>
+         </div>
 
       </div>
 


### PR DESCRIPTION
I just found it confusing, cause I thought the food/beer sections were meant to describe the upcoming event.

You'll notice, I took some creative liberties with our "image..." It's classic hipster irony though, so I'm sure @aaronzirbes will approve.

Also note, I wrote this commit using vim, so that's gotta get me some points somewhere.
